### PR TITLE
Close ActiveRecord connections at end of prefork

### DIFF
--- a/lib/spork/app_framework/rails.rb
+++ b/lib/spork/app_framework/rails.rb
@@ -6,6 +6,7 @@ class Spork::AppFramework::Rails < Spork::AppFramework
     ENV["RAILS_ENV"] ||= 'test'
     preload_rails
     yield
+    ActiveRecord::Base.remove_connection if defined?(ActiveRecord)
   end
 
   def entry_point


### PR DESCRIPTION
Fixes this issue in sporkrb (which should have been filed here :): 
https://github.com/sporkrb/spork/issues/188

In rspec, rake runs rake db:test:prepare, which drops
the test database, and if you don't close the connection
spork prevents the database from being dropped.
