### PR TITLE
Fix problem due to the difference of the implementation of Ruby 1.9.x and 2.0.0.

### DIFF
--- a/lib/spork/app_framework/rails.rb
+++ b/lib/spork/app_framework/rails.rb
@@ -65,7 +65,11 @@ class Spork::AppFramework::Rails < Spork::AppFramework
           filename = arg + "_helper"
           unless ::ActiveSupport::Dependencies.search_for_file(filename)
             # this error message must raise in the format such that LoadError#path returns the filename
-            raise LoadError.new("Missing helper file helpers/%s.rb" % filename)
+            # but in case of Rails4 and Ruby2.0, LoadError#path does not work as intended because of already exists.
+            # A simple solution to solve this problem is to set a missing file name to @path.
+            e = LoadError.new("Missing helper file helpers/%s.rb" % filename)
+            e.instance_variable_set("@path", "helpers/%s.rb" % filename)
+            raise e
           end
         end
 


### PR DESCRIPTION
I think attempting to use spork-rails with rails4 but did not work in ruby 2.0.0.
I hope this pull request will help to support rails4.
