### PR TITLE
Fix #15 reference of spork rc version

### DIFF
--- a/spork-rails.gemspec
+++ b/spork-rails.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.summary = %q{spork}
   s.test_files = Dir["features/**/*"] + Dir["spec/**/*"]
 
-  s.add_dependency "spork", ">= 1.0rc0"
+  s.add_dependency "spork", ">= 1.0.0rc0"
   s.add_dependency "rails", ">= 3.0.0", "< 3.3.0"
 end


### PR DESCRIPTION
The 1.0rc0 version does not exist on Rubygems.org.

Previously, when trying to change from spork 0.9.2 to spork-rails,
if guard-spork is already installed, bundle install will fail.
After this commit, one can run 'bundle update spork' and the new
spork-rails gem will install correctly, with the news spork 1.0.0rcX
